### PR TITLE
Add Dark/Light Theme Toggle with Persistence

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -2,8 +2,12 @@ import './Footer.css';
 import { Link } from 'react-router-dom';
 import logoSrc from '../../public/logo.png';
 
+import { useState, useEffect } from 'react';
+
 export default function Footer() {
   const year = new Date().getFullYear();
+
+
   return (
     <footer className="site-footer">
       <div className="footer-inner">

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -12,6 +12,8 @@ export default function TopBar() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [dark, setDark] = useState(() => {
     if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('theme-dark');
+      if (stored !== null) return stored === 'true';
       return document.body.classList.contains('theme-dark');
     }
     return false;
@@ -45,6 +47,7 @@ export default function TopBar() {
     } else {
       document.body.classList.remove('theme-dark');
     }
+    localStorage.setItem('theme-dark', dark);
   }, [dark]);
 
   const handleThemeToggle = () => {

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -1,34 +1,55 @@
-import homeIcon from '../assets/home.svg'
-import './TopBar.css'
-import { useLocation } from 'react-router-dom'
-import { useEffect, useState } from 'react'
+
+import homeIcon from '../assets/home.svg';
+import sunIcon from '../assets/sun.svg';
+import moonIcon from '../assets/moon.svg';
+import './TopBar.css';
+import { useLocation } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 
 export default function TopBar() {
-  const { pathname } = useLocation()
-  const isStartup = pathname.startsWith('/startup')
-  const [menuOpen, setMenuOpen] = useState(false)
+  const { pathname } = useLocation();
+  const isStartup = pathname.startsWith('/startup');
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [dark, setDark] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return document.body.classList.contains('theme-dark');
+    }
+    return false;
+  });
 
   // Close menu on route change
   useEffect(() => {
-    setMenuOpen(false)
-  }, [pathname])
+    setMenuOpen(false);
+  }, [pathname]);
 
   // Lock scroll and close with ESC
   useEffect(() => {
     const onKey = (e) => {
-      if (e.key === 'Escape') setMenuOpen(false)
-    }
+      if (e.key === 'Escape') setMenuOpen(false);
+    };
     if (menuOpen) {
-      document.documentElement.style.overflow = 'hidden'
-      window.addEventListener('keydown', onKey)
+      document.documentElement.style.overflow = 'hidden';
+      window.addEventListener('keydown', onKey);
     } else {
-      document.documentElement.style.overflow = ''
+      document.documentElement.style.overflow = '';
     }
     return () => {
-      document.documentElement.style.overflow = ''
-      window.removeEventListener('keydown', onKey)
+      document.documentElement.style.overflow = '';
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [menuOpen]);
+
+  useEffect(() => {
+    if (dark) {
+      document.body.classList.add('theme-dark');
+    } else {
+      document.body.classList.remove('theme-dark');
     }
-  }, [menuOpen])
+  }, [dark]);
+
+  const handleThemeToggle = () => {
+    setDark((prev) => !prev);
+  };
 
   return (
     <header className={`topbar${isStartup ? ' no-nav' : ''}`}>
@@ -37,6 +58,29 @@ export default function TopBar() {
         <a href="/" className="home-link" aria-label="Aller à l'accueil">
           <img src={homeIcon} alt="Accueil" className="home-icon" />
         </a>
+        <button
+          type="button"
+          className="theme-toggle-btn"
+          aria-label={dark ? 'Passer en mode clair' : 'Passer en mode sombre'}
+          onClick={handleThemeToggle}
+          style={{
+            marginLeft: '0.5rem',
+            background: 'var(--color-surface)',
+            border: '1px solid var(--color-border)',
+            borderRadius: '10px',
+            padding: '0.3rem 0.6rem',
+            display: 'flex',
+            alignItems: 'center',
+            cursor: 'pointer',
+            transition: 'background .2s, color .2s',
+          }}
+        >
+          <img
+            src={dark ? sunIcon : moonIcon}
+            alt={dark ? 'Icône soleil' : 'Icône lune'}
+            style={{ width: 20, height: 20 }}
+          />
+        </button>
       </div>
       {!isStartup && (
         <nav className="topbar-nav" aria-label="Principale">
@@ -45,7 +89,7 @@ export default function TopBar() {
           <a href="/events" className="nav-btn">Events</a>
         </nav>
       )}
-      <div className="topbar-right">
+  <div className="topbar-right">
         {!isStartup && (
           // TODO: replace with real auth links when available
           <div className="auth-buttons" aria-label="Authentication">

--- a/frontend/src/pages/Events.css
+++ b/frontend/src/pages/Events.css
@@ -1,9 +1,5 @@
 /* Calendar page styles (dark theme, matches site palette) */
 
-.events-rose { /* Scope a softer pinkish white background to Events page only */
-  --color-bg: #f3e8f8; /* soft rose white */
-}
-
 .events-layout {
   display: grid;
   grid-template-columns: 1.2fr 0.8fr;

--- a/frontend/src/pages/News.jsx
+++ b/frontend/src/pages/News.jsx
@@ -126,6 +126,7 @@ export default function News() {
           </div>
         )}
       </main>
+      <Footer />
     </div>
   )
 }

--- a/frontend/src/pages/StartupProjects.jsx
+++ b/frontend/src/pages/StartupProjects.jsx
@@ -4,6 +4,7 @@ import './Home.css';
 import './StartupProjects.css';
 import ProjectCard from '../components/ProjectCard.jsx';
 import ProjectFormModal from '../components/ProjectFormModal.jsx';
+import ProjectModal from '../components/ProjectModal.jsx';
 import { projectMock, projectTagSuggestions } from '../data/projectMock.js';
 
 export default function StartupProjects({ embedded = false }) {
@@ -13,6 +14,7 @@ export default function StartupProjects({ embedded = false }) {
     // removed tag filters
     const [modalOpen, setModalOpen] = useState(false);
     const [editing, setEditing] = useState(null); // project being edited
+    const [viewing, setViewing] = useState(null); // project being viewed (read-only)
 
     // allTags removed
 
@@ -20,7 +22,9 @@ export default function StartupProjects({ embedded = false }) {
 
     const openCreate = () => { setEditing(null); setModalOpen(true); };
     const openEdit = (p) => { setEditing(p); setModalOpen(true); };
+    const openView = (p) => { setViewing(p); };
     const closeModal = () => setModalOpen(false);
+    const closeView = () => setViewing(null);
 
     const handleSave = (payload) => {
         if (payload.id) {
@@ -54,7 +58,7 @@ export default function StartupProjects({ embedded = false }) {
                     <ProjectCard
                         key={p.id}
                         project={p}
-                        onOpen={openEdit}
+                        onOpen={openView}
                         onEdit={openEdit}
                         onDelete={handleDelete}
                     />
@@ -71,6 +75,9 @@ export default function StartupProjects({ embedded = false }) {
                 onCancel={closeModal}
                 onSave={handleSave}
             />
+            {viewing && (
+                <ProjectModal project={viewing} onClose={closeView} />
+            )}
         </div>
     );
 


### PR DESCRIPTION
## Description
This PR introduces a dark/light mode toggle to the application, allowing users to switch between light and dark themes. The toggle is now located in the TopBar, next to the home button, and uses sun/moon icons for clarity. The selected theme is persisted using localStorage, so the user's preference is retained across page navigations and reloads.

## Features
- Theme toggle button in the TopBar (sun/moon icon)
- Theme preference is saved in localStorage (persists after navigation/reload)
- Footer no longer contains the theme toggle
- Events and other pages now properly update their background according to the selected theme
- Improved user experience for both light and dark modes

## How it works
- Clicking the toggle button switches the theme instantly
- The current theme is applied to the `<body>` via the `theme-dark` class
- The user's choice is saved and restored automatically
- All main pages and backgrounds respond to the theme change

## TL;DR
- Added a persistent dark/light mode toggle in the TopBar with icons
- Theme is saved in localStorage and applied site-wide
- Footer toggle removed, all backgrounds now update correctly

## Screenshots
<img width="1710" height="1112" alt="Capture d’écran 2025-09-10 à 22 18 36" src="https://github.com/user-attachments/assets/7e23523f-47be-47c8-ae61-c56427c044c4" />
<img width="1710" height="1112" alt="Capture d’écran 2025-09-10 à 22 18 39" src="https://github.com/user-attachments/assets/a3da2f7b-4a97-4e6c-b314-d1467dea267f" />
<img width="1710" height="1112" alt="Capture d’écran 2025-09-10 à 22 18 45" src="https://github.com/user-attachments/assets/cc1abed1-1dd3-4b75-a0e5-79450f9903da" />
<img width="1710" height="1112" alt="Capture d’écran 2025-09-10 à 22 19 10" src="https://github.com/user-attachments/assets/0c844ec7-1ef6-41f0-9f1b-2a1cf1357fc1" />
